### PR TITLE
faq ui optimised

### DIFF
--- a/src/components/faq/faq.css
+++ b/src/components/faq/faq.css
@@ -189,6 +189,8 @@
     font-weight: 300;
     font-family: Arial, Helvetica, sans-serif;
     margin: 1.6em 0;
+    color: #fff;
+    opacity: 0.6;
   }
   
   @media (max-width: 750px) {
@@ -219,4 +221,23 @@
         line-height: 60px;
     }
     
+  }
+
+  @media screen and (max-width: 576px) {
+    .accordion .accordion-item {
+      margin: 10px auto;
+    }
+  }
+    @media (min-width: 769px) and (max-width: 999px) {
+    .accordion button {
+      margin: 1em auto;
+    }
+    .accordion button[aria-expanded='true'] + .accordion-content p {
+      margin: 0 auto 1.6em auto;
+    }
+  }
+  @media screen and (min-width: 769px) {
+    .accordion .accordion-item button[aria-expanded='true'] {
+      padding: 2.5em 0;
+    }
   }

--- a/src/components/faq/faq.jsx
+++ b/src/components/faq/faq.jsx
@@ -16,6 +16,7 @@ const AccordionItem = ({ title, content }) => {
     return (
         <div className={`accordion-item ${expanded ? 'expanded' : ''}`}>
             <button
+            style={{display: "flex", justifyContent: "space-between", alignItems: "center", }}
                 onClick={toggleAccordion}
                 aria-expanded={expanded ? 'true' : 'false'}
             >


### PR DESCRIPTION
Closes: #141 

## Tasks accomplished:

- Made accordions responsive with different screen sizes.
- Changed accordions' content colour to white with 50% opacity to make it visible.


## Screenshots (if any)
---
|     Original       |       Updated     |
| :-----------------: | :------------------: |
| ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/b70565e5-2b97-48b6-a554-6e39a67e0058) | ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/1363c8b2-9878-4925-9f6a-cb615f41d21b) |
|     Original       |       Updated     |
| ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/777e2857-8079-41bf-8793-e8303fa53666) | ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/bccb14e8-205e-4f26-b586-8b738cd371b5) |
|     Original       |       Updated     |
| ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/952d378a-5bfe-441c-8ef4-8bc9108e3978) | ![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/66116440/3d3a822d-5f05-4d2f-a444-3c98f6b06985) |