### PR TITLE
Hover effect of gihub logo has been updated

### DIFF
--- a/src/components/about.css
+++ b/src/components/about.css
@@ -122,18 +122,20 @@ h3 {
 }
 
 .details{
-  width: 100vw;
-  height: 50vh;
+  /* width: 100vw;
+  height: 50vh; */
   display: flex;
   justify-content: space-around;
+  padding: 0 1rem;
+  gap: 1rem;
 }
 
 .d-col{
-  height:50vh;
-  width: 30vw;
+  /* height:50vh; */
+  /* width: 30vw; */
   justify-content: center;
   background: rgb(19, 2, 42);
-  margin: auto;
+  padding: 2rem 1rem 3.5rem;
 }
 
 .title h2{


### PR DESCRIPTION
Hover effect of gihub logo has been updated with the github standard color (#238636)
![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/99585352/f1e6b49e-e2de-4712-b3b5-660b32a694d8)
