### PR TITLE
feat: add github action to lock new issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,21 @@
+name: 'Lock new issues'
+
+on:
+  issues:
+    types: opened
+
+permissions:
+  issues: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v3
+        with:
+          close-issue: false
+          exclude-issue-labels: 'status: ready for dev'
+          process-only: 'issues'
+          skip-closed-issue-comment: true
+          issue-comment: >
+            To reduce notifications, issues are locked. Your issue will be unlock when we will add label as `status: ready for dev`.  Check out the [Readme](https://github.com/abhijeet141/CropForesight-FrontEnd/blob/main/README.md) for more information.


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Issue 

<!-- Example: #104 -->
Closes #203 

### Files added
- `.github/workflows/lock.yml`

### To run this workflow you need to enable the following permission:

1. **Go to your project repository settings**
2. **On left pane > Actions > General**

![image](https://github.com/subhashis2204/project-annapurna/assets/130365071/b6748b8d-0d8c-4662-8fb9-4828e049a69e)

3. **Scroll down and Go to Workflow permissions > select "Read and write permissions"**

![image](https://github.com/subhashis2204/project-annapurna/assets/130365071/28c022ba-2ddc-4dbd-a2fa-2cc8c5380009)

4. **Click save and its done.**
## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just add x inside them for example [x] like this----->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


@abhijeet141 Please review this PR.
Thanks