### PR TITLE
Enhance the UI of the example page

### DIFF
--- a/src/components/ExampleOfCrop/ExampleCrop.css
+++ b/src/components/ExampleOfCrop/ExampleCrop.css
@@ -3,12 +3,14 @@
   width: 7rem !important;
   border-radius: 15%;
   opacity: 0.6;
+  transition: all ease 2s;
 }
+/* 
 .Avtar:hover {
-  scale: 1.5;
+  scale: 1.2;
   opacity: 1;
   cursor: pointer;
-}
+} */
 .table_E {
   margin-left: auto;
   margin-right: auto;
@@ -18,6 +20,8 @@
 .thead_E {
   border-bottom: 1px solid black;
   border: 2px solid rgb(112, 111, 112);
+  padding-top: 5px;
+  padding-bottom: 5px;
   color: rgb(229, 160, 250);
 }
 
@@ -25,20 +29,39 @@ td {
   padding-right: 5rem;
   padding-left: 5rem;
   text-align: center;
-  border: 2px solid rgb(112, 111, 112);
+  /* border: 2px solid rgb(112, 111, 112); */
 }
 .Crop_table {
   justify-content: center !important;
   align-items: center !important;
 }
+
+.form_E{
+  margin: auto;
+  margin-bottom: 1rem;
+}
+
 .input_E {
-  min-width: 540px !important;
+  width: 100% ;
+  
 }
 .h1_E {
   margin-top: 5rem;
+  margin-inline:auto;
+  width: 100%;
+  text-align: center;
 }
 .tbody_E tr:nth-child(odd) {
   background-color: rgb(0, 0, 57);
+}
+
+.rowex{
+  transition: 500ms all ease;
+}
+
+.rowex:hover{
+  scale: 1.04;
+  box-shadow: rgba(9, 30, 66, 0.25) 0px 4px 8px -2px, rgba(9, 30, 66, 0.08) 0px 0px 0px 1px;
 }
 
 .tbody_E tr:nth-child(even) {

--- a/src/components/ExampleOfCrop/ExampleCrop.jsx
+++ b/src/components/ExampleOfCrop/ExampleCrop.jsx
@@ -8,15 +8,15 @@ export function ExampleCrop() {
   const [search, setSearch] = useState("");
 
   return (
-    <>
+    <div className="backdrop-opacity-10 backdrop-invert bg-white/30">
       <NAV />
       <h1 className="h1_E">Find your crop </h1>
-      <form className="form_E">
+      <form className="form_E" >
         <input
           placeholder="Input season to find your crop"
           onChange={(e) => setSearch(e.target.value)}
           type="text"
-          className="input_E"
+          className={`input_E `}
         ></input>
       </form>
 
@@ -35,7 +35,7 @@ export function ExampleCrop() {
               ? card
               : card.season.toLowerCase().includes(search);
           }).map((card, index) => (
-            <tr>
+            <tr className="rowex">
               <td>{card.sl}</td>
               <td>{card.season}</td>
               <td>{card.head}</td>
@@ -46,6 +46,6 @@ export function ExampleCrop() {
           ))}
         </tbody>
       </table>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
I have improved the Ui of the Example page, made a better list format that enhances the look of the page and the crop information.

## Issue Number
#192 

i had made suffice changes .
As i am well aware that the dark mode is about to come in the site and the current color scheme make it difficult to made significant changes in the site . 
Here is the best i could come up with 

In hover on item state-
![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/74443858/c74b07bd-2565-45a5-909b-073a1a2fd5f4)

Normal state-
![image](https://github.com/abhijeet141/CropForesight-FrontEnd/assets/74443858/23da971d-46aa-41ea-a257-d6bff4ac3978)

- [x] The animations are made smmoth
- [x] The theme of site is well maintained 
- [x] minimilistic , accurate changes made in the code.
   
