### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center" id="top">CropForesight (Frontend)</h1>
-<p align="center">This Repository includes the frontend code of the <a href="crop-foresight-front-end.vercel.app" >CropForesight</a> webiste. The frontend of the project is written in HTML, CSS, Javascript, and ReactJS. Before moving ahead, a short intro about the project.</p>
+<p align="center">This Repository includes the frontend code of the <a href="crop-foresight-front-end.vercel.app" >CropForesight</a> website. The frontend of the project is written in HTML, CSS, Javascript, and ReactJS. Before moving ahead, a short intro about the project.</p>
 
 
  <h1 align="center">CropForesight🌾</h1>


### PR DESCRIPTION
Fixed small typo in README.md.

In this line the word `webiste` is corrected to `website`:
This Repository includes the frontend code of the [CropForesight](https://github.com/nikohoffren/CropForesight-FrontEnd/blob/fix-typo/crop-foresight-front-end.vercel.app) website.